### PR TITLE
Fixed intervention model for discrete environments

### DIFF
--- a/mile/computational_model.py
+++ b/mile/computational_model.py
@@ -93,8 +93,8 @@ def computational_intervention_model(state: torch.Tensor,
         policy_expected_action_probs = F.softmax(policy_expected_action_probs, dim=1)
         mean = torch.tensor([0.0], device=state.device)
         std_dev = torch.tensor([1.0], device=state.device)
-        inside_cdf = (mental_model_expected_action_probs * torch.log(policy_expected_action_probs)).sum(dim=1)
-        inside_cdf = policy_expected_action_probs - inside_cdf
+        inside_cdf = (mental_model_expected_action_probs * torch.log(policy_expected_action_probs)).sum(dim=1, keepdim=True)
+        inside_cdf = torch.log(policy_expected_action_probs) - inside_cdf
         inside_cdf = inside_cdf - cost
         intervention_prob = (policy_expected_action_probs * torch.distributions.Normal(mean, std_dev).cdf(inside_cdf)).sum(dim=1)
         total_prob = torch.ones((policy_expected_action_probs.shape[0],policy_expected_action_probs.shape[1]+1), device=state.device)


### PR DESCRIPTION
For discrete action environments, the `inside_cdf` term seems to be missing a `torch.log` operation on the expected action probabilities from the intervention policy (i.e. `pi_h` in the paper) according to the [paper's](https://arxiv.org/pdf/2502.13519#page=3) computational intervention model and formula for the probability of intervention at a given state.

Additionally, this PR fixes an error that arises from computing the intervention probabilities when the action space is discrete by forgetting to set `keepdim=True` in [computational_model.py](https://github.com/USC-Lira/mile-code/blob/main/mile/computational_model.py#L96) leading to a shape mismatch runtime error in future operations.

Please let me know if these changes were intentional or if I am missing something! Thanks! 